### PR TITLE
fix CLI parameter name mixup for --host vs. --hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Options:
   --rpcUrl [rpcUrl]                                            either rpcUrl or chainId must be provided (env: FIREBLOCKS_RPC_URL)
   --http                                                       run an http server instead of using IPC (env: FIREBLOCKS_HTTP)
   --port [port]                                                http server port (env: FIREBLOCKS_PORT)
-  --host [host]                                                http server host (env: FIREBLOCKS_HOST)
+  --hostname [host]                                            http server host, default 127.0.0.1 - use 0.0.0.0 to listen on all interfaces (env: FIREBLOCKS_HOSTNAME)
   --path [path]                                                http api endpoint path (env: FIREBLOCKS_PATH)
   --ipcPath [path]                                             IPC path to listen on, defaults to '~/.fireblocks/json-rpc.ipc' on linux and macos, and
                                                                '\\.\pipe\fireblocks-json-rpc.ipc' on windows (default: "/Users/user/.fireblocks/json-rpc.ipc", env:

--- a/src/command.ts
+++ b/src/command.ts
@@ -16,7 +16,7 @@ export function createFireblocksJsonRpcCommand() {
 
         .addOption(new Option("--http", "run an http server instead of using IPC").env("FIREBLOCKS_HTTP"))
         .addOption(new Option("--port [port]", "http server port").env("FIREBLOCKS_PORT"))
-        .addOption(new Option("--host [host]", "http server host").env("FIREBLOCKS_HOST"))
+        .addOption(new Option("--hostname [host]", "http server host, default 127.0.0.1 - use 0.0.0.0 to listen on all interfaces").env("FIREBLOCKS_HOSTNAME"))
         .addOption(new Option("--path [path]", "http api endpoint path").default(undefined, '/${--apiKey}').env("FIREBLOCKS_PATH"))
         .addOption(new Option("--ipcPath [path]", `IPC path to listen on, defaults to '${LINUX_DEFAULT_IPC_PATH}' on linux and macos, and '${WINDOWS_DEFAULT_IPC_PATH}' on windows`).default(DEFAULT_IPC_PATH).env("FIREBLOCKS_IPC_PATH"))
         .addOption(new Option("--env [env_var_name]", "sets the listening address as an environment variable").default(DEFAULT_ENV_VAR).env("FIREBLOCKS_JSON_RPC_ENV_VAR"))


### PR DESCRIPTION
The current documentation and CLI config states to use `--host` to set the interface to bind to.

Starting it with eg. `--http --host 0.0.0.0` starts with this output:
```
Fireblocks JSON-RPC server listening on
http://127.0.0.1:50005/1234
```
and its really only listening on `127.0.0.1` instead of `0.0.0.0`

--> there is a naming mismatch between `FireblocksProviderConfig` ( [here](https://github.com/fireblocks/fireblocks-json-rpc/blob/main/src/types.ts#L5) ) and the CLI command.js  ( [here](https://github.com/fireblocks/fireblocks-json-rpc/blob/main/src/command.ts#L19) ) config -> this PR changes the `--host` - parameter to `--hostname` to keep it in line with `FireblocksProviderConfig`
