### PR TITLE
Add assetId flag to allow for using networks not in the defaults list

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -24,6 +24,7 @@ export function createFireblocksJsonRpcCommand() {
         .addOption(new Option("--privateKey <path_or_contents>", "Fireblocks API private key").env("FIREBLOCKS_API_PRIVATE_KEY_PATH").makeOptionMandatory())
         .addOption(new Option("--chainId [chainId]", "Either chainId or rpcUrl must be provided").env("FIREBLOCKS_CHAIN_ID"))
         .addOption(new Option("--rpcUrl [rpcUrl]", "Either rpcUrl or chainId must be provided").env("FIREBLOCKS_RPC_URL"))
+        .addOption(new Option("--assetId [assetId]", "Fireblocks asset ID").env("FIREBLOCKS_ASSET_ID"))
 
         .addOption(new Option("--http", "Run an HTTP server instead of using IPC").env("FIREBLOCKS_HTTP"))
         .addOption(new Option("--port [port]", "HTTP server port").default(DEFAULT_PORT).env("FIREBLOCKS_PORT"))


### PR DESCRIPTION
This CLI uses the list in `fireblocks-web3-provider` to resolve the asset ID for a given network. This list does not include all assets/networks supported by Fireblocks. This PR adds an `assetId` flag to the CLI options to allow for manually specifying the asset ID when it is missing from `fireblocks-web3-provider`.

I've run into this issue a few times now and have previously fixed it by modifying the code in `fireblocks-web3-provider` (see https://github.com/fireblocks/fireblocks-web3-provider/pull/60 ). This PR provides a solution that will allow me to stop monkey-patching `fireblocks-web3-provider` when it doesn't contain the asset I am trying to use in its defaults list.
